### PR TITLE
Custom Pagination Hook

### DIFF
--- a/the-toad-tribune/src/api/newsApi.ts
+++ b/the-toad-tribune/src/api/newsApi.ts
@@ -84,8 +84,6 @@ export const getNewsEverything = async (
       }
     });
 
-    console.log(sources);
-
     queryString += `&sources=${sources}`;
   }
 
@@ -167,8 +165,6 @@ export const getNewsTopHeadlines = async (
         sources += `,${source}`;
       }
     });
-
-    console.log(sources);
 
     queryString += `&sources=${sources}`;
   }

--- a/the-toad-tribune/src/hooks/index.ts
+++ b/the-toad-tribune/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import usePagination from "./usePagination";
+
+export { usePagination };

--- a/the-toad-tribune/src/hooks/usePagination.ts
+++ b/the-toad-tribune/src/hooks/usePagination.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+/**
+ * Creates a pageNumber state with functions that handles the
+ * pagination.
+ * @returns {[onNextButton,onPrevButton,pageNumber,startBeginning,startEnd]} An array that contains onNextButton function,
+ * onPrevButton function, pageNumber state, startBeginning
+ * function, startEnd function.
+ */
+const usePagination = () => {
+  const [pageNumber, setPageNumber] = useState(0);
+
+  const onNextButton = () => setPageNumber((prevIndex) => prevIndex + 1);
+
+  const onPrevButton = () => setPageNumber((prevIndex) => prevIndex - 1);
+
+  const startBeginning = () => setPageNumber(0);
+
+  const startEnd = (endIndex: number) => setPageNumber(endIndex);
+
+  return [
+    onNextButton,
+    onPrevButton,
+    pageNumber,
+    startBeginning,
+    startEnd,
+  ] as const;
+};
+
+export default usePagination;

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -1,44 +1,36 @@
 import styled from "styled-components";
 import { NewsResponse } from "../api/newsApi";
-import { useState } from "react";
+import { usePagination } from "../hooks";
+
 interface MainArticleProps {
   mainArticle: NewsResponse;
 }
 
 const MainArticle: React.FC<MainArticleProps> = ({ mainArticle }) => {
-  const [mainArticleIndex, setMainArticleIndex] = useState(0);
+  const [onNextButton, onPrevButton, pageNumber, startBeginning, startEnd] =
+    usePagination();
 
-  const onNextButton = () => setMainArticleIndex((prevIndex) => prevIndex + 1);
-
-  const onPrevButton = () => setMainArticleIndex((prevIndex) => prevIndex - 1);
-
-  const startBeginning = () => setMainArticleIndex(0);
-
-  const startEnd = (endIndex: number) => setMainArticleIndex(endIndex);
-
-  const article = mainArticle.articles?.[mainArticleIndex];
+  const article = mainArticle.articles?.[pageNumber];
 
   return mainArticle.articles.length ? (
     <MainArticleStyles>
       <button
         onClick={() => {
-          mainArticle.articles.length - 1 === mainArticleIndex
+          mainArticle.articles.length - 1 === pageNumber
             ? startBeginning()
             : onNextButton();
         }}
       >
-        {" "}
-        Next Button{" "}
+        Next Button
       </button>
       <button
         onClick={() => {
-          mainArticleIndex === 0
+          pageNumber === 0
             ? startEnd(mainArticle.articles.length - 1)
             : onPrevButton();
         }}
         className="add-class"
       >
-        {" "}
         Previous Button
       </button>
       <div>


### PR DESCRIPTION
## Changes
1. Created a custom hook for pagination to be re-used everywhere.

## Purpose
There needs to be a custom hook for pagination to be re-used.

## Approach
In order to use the pagination functionalities from `MainArticle.tsx` to be re-used everywhere on future components, a custom hook component was created called `usePagination.ts`.

## Learning
[TypeScript + React: Typing custom hooks with tuple types](https://fettblog.eu/typescript-react-typeing-custom-hooks/)

Closes #15 