### PR TITLE
Pagination Bugs

### DIFF
--- a/the-toad-tribune/src/SubApp.tsx
+++ b/the-toad-tribune/src/SubApp.tsx
@@ -76,6 +76,9 @@ const SubApp = () => {
   
   const [serverErrorMessage, setServerErrorMessage] = useState<string>("");
 
+
+  const [pageNumber, setPageNumber] = useState<number>(1);
+
   const [darkMode, setdarkMode] = useState<Boolean>(true);
 
   const newsDataGrabber = () => {
@@ -233,6 +236,7 @@ const SubApp = () => {
             renderMainLayoutPage={renderMainLayoutPage}
             renderSearchPage={renderSearchPage}
             setdarkMode={setdarkMode}
+            setPageNumber={setPageNumber}
             setSearchValue={setSearchValue}
             setSearchResults={setSearchResults}
           />
@@ -248,9 +252,11 @@ const SubApp = () => {
         SearchResults={
           <SearchResults
             darkMode={darkMode}
+            pageNumber={pageNumber}
             renderMoreInfoPage={renderMoreInfoPage}
             searchResults={searchResults}
             searchValue={searchValue}
+            setPageNumber={setPageNumber}
             setSnackbarMessage={setServerErrorMessage}
             setSearchResults={setSearchResults}
             setSelectedArticle={setSelectedArticle}

--- a/the-toad-tribune/src/SubApp.tsx
+++ b/the-toad-tribune/src/SubApp.tsx
@@ -251,6 +251,7 @@ const SubApp = () => {
             renderMoreInfoPage={renderMoreInfoPage}
             searchResults={searchResults}
             searchValue={searchValue}
+            setSnackbarMessage={setServerErrorMessage}
             setSearchResults={setSearchResults}
             setSelectedArticle={setSelectedArticle}
           />

--- a/the-toad-tribune/src/assets/next-button.svg
+++ b/the-toad-tribune/src/assets/next-button.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="200.000000pt" height="200.000000pt" viewBox="0 0 200.000000 200.000000"
+ preserveAspectRatio="xMidYMid meet">
+
+<g transform="translate(0.000000,200.000000) scale(0.100000,-0.100000)"
+fill="#000000" stroke="none">
+<path d="M556 1884 c-9 -8 -16 -20 -16 -26 0 -5 130 -143 289 -306 158 -164
+343 -354 411 -424 l122 -128 -122 -127 c-68 -71 -253 -261 -411 -425 -159
+-163 -289 -301 -289 -306 0 -15 29 -42 44 -42 13 0 851 856 869 886 4 8 4 20
+0 28 -18 30 -857 886 -869 886 -7 0 -20 -7 -28 -16z"/>
+</g>
+</svg>

--- a/the-toad-tribune/src/assets/prev-button.svg
+++ b/the-toad-tribune/src/assets/prev-button.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="200.000000pt" height="200.000000pt" viewBox="0 0 200.000000 200.000000"
+ preserveAspectRatio="xMidYMid meet">
+
+<g transform="translate(0.000000,200.000000) scale(0.100000,-0.100000)"
+fill="#000000" stroke="none">
+<path d="M979 1464 c-233 -240 -428 -443 -432 -450 -4 -8 -4 -20 0 -28 18 -30
+857 -886 869 -886 15 0 44 27 44 42 0 5 -130 143 -289 306 -158 164 -343 354
+-411 425 l-122 127 122 128 c68 70 253 260 411 424 159 163 289 301 289 306 0
+15 -29 42 -44 42 -8 0 -204 -196 -437 -436z"/>
+</g>
+</svg>

--- a/the-toad-tribune/src/layout/Navgation.tsx
+++ b/the-toad-tribune/src/layout/Navgation.tsx
@@ -10,6 +10,7 @@ interface INavProps {
   renderMainLayoutPage: Function;
   renderSearchPage: Function;
   setdarkMode: Function;
+  setPageNumber: Function;
   setSearchValue: Function;
   setSearchResults: Function;
 }
@@ -19,6 +20,7 @@ const Navigation: React.FC<INavProps> = ({
   renderMainLayoutPage,
   renderSearchPage,
   setdarkMode,
+  setPageNumber,
   setSearchResults,
   setSearchValue,
 }) => {
@@ -39,6 +41,7 @@ const Navigation: React.FC<INavProps> = ({
           if (results.totalResults > 0) {
             setSearchValue(validateSearchValue);
             setSearchResults(results);
+            setPageNumber(1);
             renderSearchPage();
           } else {
             setSearchError("Please enter a valid search value.");

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { getNewsEverything, NewsEverythingRequest } from "../api";
 import type { INewsResponse } from "../api";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
 import PrevIcon from "../commons/prev.png";
 import NextIcon from "../commons/next.png";
 import { DarkModeProps } from "../api/newsApi";
@@ -137,10 +139,11 @@ const SearchResults: React.FC<SearchResultsProps> = ({
               pageNumber > 1 && getPrevPage();
             }}
           >
-            <img
-              src={PrevIcon}
+            {/* <img
+              src={PreviousButtonIcon}
               alt="previous button"
-            />
+            /> */}
+            <PreviousButtonIconComponent />
           </div>
           <span className="page-results">{`${pageNumber}/${totalPages}`}</span>
           <div
@@ -149,7 +152,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({
             }}
             className="up-btn"
           >
-            <img src={NextIcon} alt="next button" />
+            {/* <img src={NextButtonIcon} alt="next button" /> */}
+            <NextButtonIconComponent />
           </div>
         </div>
       )}
@@ -184,7 +188,7 @@ const ArticleContainerStyles = styled.div<DarkModeProps>`
 
     .down-btn,
     .up-btn {
-      background-color: grey;
+      background-color: ${(props) => (props.darkMode ? "#1a1a1a" : "#e3dac9")};
       height: 2.5rem;
       width: 2.5rem;
       border-radius: 50%;
@@ -192,12 +196,16 @@ const ArticleContainerStyles = styled.div<DarkModeProps>`
       display: flex;
       align-items: center;
       justify-content: center;
-      box-shadow: 1px 2px 2px 1px lightgrey;
-      border: 1px solid black;
+      /* box-shadow: 1px 2px 2px 1px lightgrey; */
+      border: double;
 
-      img {
+      svg {
         height: 1.6rem;
         width: 1.6rem;
+
+        & g {
+          fill: ${(props) => (props.darkMode) ? "#e3dac9" : "#1a1a1a"}
+        }
       }
 
       &:hover {

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -132,11 +132,12 @@ const SearchResults: React.FC<SearchResultsProps> = ({
       {renderResults()}
       {searchResults.articles.length > 0 && (
         <div className="btn-container">
-          <div className="down-btn">
+          <div className="down-btn"
+            onClick={() => {
+              pageNumber > 1 && getPrevPage();
+            }}
+          >
             <img
-              onClick={() => {
-                pageNumber > 1 && getPrevPage();
-              }}
               src={PrevIcon}
               alt="previous button"
             />

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -4,15 +4,15 @@ import { getNewsEverything, NewsEverythingRequest } from "../api";
 import type { INewsResponse } from "../api";
 import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
 import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
 import { DarkModeProps } from "../api/newsApi";
 
 interface SearchResultsProps {
   darkMode: Boolean;
+  pageNumber: number;
   renderMoreInfoPage: Function;
   searchResults: INewsResponse;
   searchValue: string;
+  setPageNumber: Function;
   setSnackbarMessage: Function;
   setSearchResults: Function;
   setSelectedArticle: Function;
@@ -20,14 +20,15 @@ interface SearchResultsProps {
 
 const SearchResults: React.FC<SearchResultsProps> = ({
   darkMode,
+  pageNumber,
   renderMoreInfoPage,
   searchResults,
   searchValue,
+  setPageNumber,
   setSnackbarMessage,
   setSearchResults,
   setSelectedArticle,
 }) => {
-  const [pageNumber, setPageNumber] = useState<number>(1);
   const [totalPages, setTotalPages] = useState<number>(1);
 
   const getTotalPages = () => {
@@ -54,7 +55,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   }, [searchResults]);
 
   const getNextPage = () => {
-    setPageNumber((prevPageNumber) => prevPageNumber + 1);
+    setPageNumber((prevPageNumber:number) => prevPageNumber + 1);
 
     const searchStuff = new NewsEverythingRequest({
       q: searchValue,
@@ -75,7 +76,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   };
 
   const getPrevPage = () => {
-    setPageNumber((prevPageNumber) => prevPageNumber - 1);
+    setPageNumber((prevPageNumber:number) => prevPageNumber - 1);
 
     const searchStuff = new NewsEverythingRequest({
       q: searchValue,
@@ -139,10 +140,6 @@ const SearchResults: React.FC<SearchResultsProps> = ({
               pageNumber > 1 && getPrevPage();
             }}
           >
-            {/* <img
-              src={PreviousButtonIcon}
-              alt="previous button"
-            /> */}
             <PreviousButtonIconComponent />
           </div>
           <span className="page-results">{`${pageNumber}/${totalPages}`}</span>
@@ -152,7 +149,6 @@ const SearchResults: React.FC<SearchResultsProps> = ({
             }}
             className="up-btn"
           >
-            {/* <img src={NextButtonIcon} alt="next button" /> */}
             <NextButtonIconComponent />
           </div>
         </div>
@@ -196,7 +192,6 @@ const ArticleContainerStyles = styled.div<DarkModeProps>`
       display: flex;
       align-items: center;
       justify-content: center;
-      /* box-shadow: 1px 2px 2px 1px lightgrey; */
       border: double;
 
       svg {

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -179,6 +179,7 @@ const ArticleContainerStyles = styled.div<DarkModeProps>`
   .btn-container {
     display: flex;
     margin-top: 2rem;
+    margin-bottom: 2rem;
     align-items: center;
 
     .down-btn,

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -142,7 +142,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
               alt="previous button"
             />
           </div>
-          <span>{`${pageNumber}/${totalPages}`}</span>
+          <span className="page-results">{`${pageNumber}/${totalPages}`}</span>
           <div
             onClick={() => {
               pageNumber < totalPages && getNextPage();
@@ -172,7 +172,7 @@ const ArticleContainerStyles = styled.div<DarkModeProps>`
   background-color: ${(props) => (props.darkMode ? "#1a1a1a" : "#e3dac9")};
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
 
-  span:nth-of-type(1) {
+  span:nth-of-type(1):not(.page-results) {
     cursor: pointer;
   }
 
@@ -197,6 +197,10 @@ const ArticleContainerStyles = styled.div<DarkModeProps>`
       img {
         height: 1.6rem;
         width: 1.6rem;
+      }
+
+      &:hover {
+        cursor: pointer;
       }
     }
   }

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -11,6 +11,7 @@ interface SearchResultsProps {
   renderMoreInfoPage: Function;
   searchResults: INewsResponse;
   searchValue: string;
+  setSnackbarMessage: Function;
   setSearchResults: Function;
   setSelectedArticle: Function;
 }
@@ -20,6 +21,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   renderMoreInfoPage,
   searchResults,
   searchValue,
+  setSnackbarMessage,
   setSearchResults,
   setSelectedArticle,
 }) => {
@@ -47,21 +49,43 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 
   const getNextPage = () => {
     setPageNumber((prevPageNumber) => prevPageNumber + 1);
+
     const searchStuff = new NewsEverythingRequest({
       q: searchValue,
       page: pageNumber + 1,
     });
-    getNewsEverything(searchStuff).then((results) => setSearchResults(results));
+
+    getNewsEverything(searchStuff).then((results) => {
+      if (results.status === "ok") {
+        setSearchResults(results)
+      }
+
+      if (results.status === "error") {
+        setSnackbarMessage(results.message);
+      }
+    });
+
     scrollToTop();
   };
 
   const getPrevPage = () => {
     setPageNumber((prevPageNumber) => prevPageNumber - 1);
+
     const searchStuff = new NewsEverythingRequest({
       q: searchValue,
       page: pageNumber - 1,
     });
-    getNewsEverything(searchStuff).then((results) => setSearchResults(results));
+
+    getNewsEverything(searchStuff).then((results) => {
+      if (results.status === "ok") {
+        setSearchResults(results);
+      }
+
+      if (results.status === "error") {
+        setSnackbarMessage(results.message);
+      }
+    });
+    
     scrollToTop();
   };
 

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -29,10 +29,14 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   const [totalPages, setTotalPages] = useState<number>(1);
 
   const getTotalPages = () => {
-    if (searchResults.totalResults % 20 === 0) {
-      setTotalPages(searchResults.totalResults / 20);
+    if (searchResults.totalResults <= 100) {
+      if (searchResults.totalResults % 20 === 0) {
+        setTotalPages(searchResults.totalResults / 20);
+      } else {
+        setTotalPages(Math.floor(searchResults.totalResults / 20) + 1);
+      }
     } else {
-      setTotalPages(Math.floor(searchResults.totalResults / 20) + 1);
+      setTotalPages(5);
     }
   };
 
@@ -57,7 +61,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 
     getNewsEverything(searchStuff).then((results) => {
       if (results.status === "ok") {
-        setSearchResults(results)
+        setSearchResults(results);
       }
 
       if (results.status === "error") {
@@ -85,7 +89,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         setSnackbarMessage(results.message);
       }
     });
-    
+
     scrollToTop();
   };
 


### PR DESCRIPTION
## Changes
1. Fixed the `totalResults` for the pagination so that it would not call the News API with greater than 5 pages.
2. Handled the pagination server response with the `Snackbar` component so any errors would not break the end, and display a friendly message.
3. Added a cursor when hovering the pagination buttons.
4. Added `margin-bottom` to the pagination container so there could be space from the bottom.
5. Changed the location of the `onClick` function for "down-btn" to be on the `div` parent element and not its `img` child element.
6. Added a Dark Theme to the pagination buttons.
7. Reset the pagination state back to 1 if the user enters a new search field.

## Purpose
The purpose of this PR is to fix a few bugs on the pagination such as the limit of calling the `page` query parameter for the News API, handling the server responses when paginating, there were no cursors for the pagination buttons, the location of the `onClick` should not be in the `img` element, there were no Dark Theme on the pagination buttons, and the pagination state was not being reset back to 1 when a user enters a new search field.

## Approach
As described in the **Purpose** section above, all of these issues became resolved.

Closes #70 
Closes #72 
Closes #76 
Closes #78 
Closes #80 
Closes #81 
Closes #82 