### PR TITLE
Fix Buttons to Appear

### DIFF
--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -40,7 +40,7 @@ export const HeaderContainer2 = styled.div`
   margin-top: 0.2rem;
 
   h3 {
-    margin: 0.5rem;
+    margin: 0.25rem;
     text-align: center;
     line-height: 1.5rem;
     font-family: 'Oswald', sans-serif;

--- a/the-toad-tribune/src/commons/buttons.ts
+++ b/the-toad-tribune/src/commons/buttons.ts
@@ -1,13 +1,15 @@
 import styled from "styled-components";
+import { DarkModeProps } from "./darkMode";
 
-export const Buttons = styled.button`
+export const Buttons = styled.button<DarkModeProps>`
   height: 1.7rem;
   width: 1.7rem;
   display: flex;
   align-items: center;
   justify-content: center;
   border: double;
-  background-color: rgba(255, 255, 255, 0.5);
+  background-color: ${(props) => (props.darkMode ? "#1a1a1a" : "#e3dac9")};
+  color: ${(props) => (props.darkMode) ? "#e3dac9" : "#1a1a1a"};
   border-radius: 50%;
   margin: 0.7rem;
   cursor: pointer;
@@ -15,12 +17,19 @@ export const Buttons = styled.button`
   img {
     height: 1rem;
     width: 1rem;
-    color: #fff;
   }
 
-  img {
-    height: 1rem;
-    width: 1rem;
-    color: #fff;
+  svg {
+    height: 1.6rem;
+    width: 1.6rem;
+
+    & g {
+      fill: ${(props) => (props.darkMode) ? "#e3dac9" : "#1a1a1a"};
+    }
+
+    path {
+      stroke: ${(props) => (props.darkMode) ? "#e3dac9" : "#1a1a1a"};
+      stroke-width: 250px;
+    }
   }
 `;

--- a/the-toad-tribune/src/layout/Animals.tsx
+++ b/the-toad-tribune/src/layout/Animals.tsx
@@ -10,8 +10,8 @@ import {
   ImageContainer2,
 } from "../commons";
 import { DarkModeProps } from "../api/newsApi";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
 import { dateConverter } from "../utils/dateConverter";
 import { keyframes } from "styled-components";
 
@@ -35,9 +35,10 @@ const Animals: React.FC<INewsProps> = ({
             ? startEnd(articleResponse.articles.length - 1)
             : onPrevButton();
         }}
-        className="add-class"
+        className="left-button"
+        darkMode={darkMode}
       >
-        <img src={PrevIcon} alt="arrow pointing left" />
+        <PreviousButtonIconComponent />
       </Buttons>
 
       <ArticleContentContainer2
@@ -68,8 +69,10 @@ const Animals: React.FC<INewsProps> = ({
             ? startBeginning()
             : onNextButton();
         }}
+        className="right-button"
+        darkMode={darkMode}
       >
-        <img src={NextIcon} alt="arrow pointing right" />
+        <NextButtonIconComponent />
       </Buttons>
     </AnimalsStyles>
   ) : (
@@ -99,6 +102,28 @@ const AnimalsStyles = styled.div<DarkModeProps>`
   margin-bottom: 0.5em;
   cursor: pointer;
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
+  position: relative;
+
+  button {
+    opacity: 0;
+    position: absolute;
+    transition: all 0.5s ease;
+    top: 0;
+
+    &.left-button {
+      left: 0;
+    }
+
+    &.right-button {
+      right: 0;
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
+  }
 `;
 
 const textFlash = keyframes`

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -2,8 +2,8 @@ import styled from "styled-components";
 import type { INewsProps } from "../api";
 import { usePagination } from "../hooks";
 import { Buttons } from "../commons";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
 import { DarkModeProps } from "../api/newsApi";
 import { dateConverter } from "../utils/dateConverter";
 import { keyframes } from "styled-components";
@@ -27,9 +27,10 @@ const MainArticle: React.FC<INewsProps> = ({
             ? startEnd(articleResponse.articles.length - 1)
             : onPrevButton();
         }}
-        className="add-class"
+        className="left-button"
+        darkMode={darkMode}
       >
-        <img src={PrevIcon} alt="arrow pointing left" />
+        <PreviousButtonIconComponent />
       </Buttons>
 
       <h3 className="main-article-title">Top Headlines</h3>
@@ -62,8 +63,10 @@ const MainArticle: React.FC<INewsProps> = ({
             ? startBeginning()
             : onNextButton();
         }}
+        className="right-button"
+        darkMode={darkMode}
       >
-        <img src={NextIcon} alt="arrow pointing right" />
+        <NextButtonIconComponent />
       </Buttons>
     </MainArticleStyles>
   ) : (
@@ -111,6 +114,27 @@ const MainArticleStyles = styled.div<DarkModeProps>`
 
   .img-container {
     width: 70%;
+  }
+
+  button {
+    opacity: 0;
+    position: absolute;
+    transition: all 0.5s ease;
+    top: 0;
+
+    &.left-button {
+      left: 0;
+    }
+
+    &.right-button {
+      right: 0;
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
   }
 `;
 

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -9,8 +9,8 @@ import {
   ImageContainer2,
 } from "../commons";
 import { DarkModeProps } from "../api/newsApi";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
 import { dateConverter } from "../utils/dateConverter";
 import { keyframes } from "styled-components";
 
@@ -33,8 +33,10 @@ const Movies: React.FC<INewsProps> = ({
             ? startEnd(articleResponse.articles.length - 1)
             : onPrevButton();
         }}
+        className="left-button"
+        darkMode={darkMode}
       >
-        <img src={PrevIcon} alt="arrow pointing left" />
+        <PreviousButtonIconComponent />
       </Buttons>
 
       <ArticleContentContainer2
@@ -65,8 +67,10 @@ const Movies: React.FC<INewsProps> = ({
             ? startBeginning()
             : onNextButton();
         }}
+        className="right-button"
+        darkMode={darkMode}
       >
-        <img src={NextIcon} alt="arrow pointing right" />
+        <NextButtonIconComponent />
       </Buttons>
     </MoviesStyles>
   ) : (
@@ -103,6 +107,28 @@ const MoviesStyles = styled.div<DarkModeProps>`
   justify-content: center;
   align-items: center;
   padding-top: 1rem;
+  position: relative;
+
+  button {
+    opacity: 0;
+    position: absolute;
+    transition: all 0.5s ease;
+    top: 0;
+
+    &.left-button {
+      left: 0;
+    }
+
+    &.right-button {
+      right: 0;
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
+  }
 `;
 
 const textFlash = keyframes`

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -9,8 +9,8 @@ import {
   ImageContainer2,
 } from "../commons";
 import { DarkModeProps } from "../api/newsApi";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg"
 import { dateConverter } from "../utils/dateConverter";
 import { keyframes } from "styled-components";
 
@@ -33,9 +33,10 @@ const Politics: React.FC<INewsProps> = ({
             ? startEnd(articleResponse.articles.length - 1)
             : onPrevButton();
         }}
-        className="add-class"
+        className="left-button"
+        darkMode={darkMode}
       >
-        <img src={PrevIcon} alt="arrow pointing left" />
+        <PreviousButtonIconComponent />
       </Buttons>
 
       <ArticleContentContainer2
@@ -66,8 +67,10 @@ const Politics: React.FC<INewsProps> = ({
             ? startBeginning()
             : onNextButton();
         }}
+        className="right-button"
+        darkMode={darkMode}
       >
-        <img src={NextIcon} alt="arrow pointing right" />
+        <PreviousButtonIconComponent />
       </Buttons>
     </PoliticsStyles>
   ) : (
@@ -94,13 +97,36 @@ const PoliticsStyles = styled.div<DarkModeProps>`
   border-left: none;
   border-top: none;
   border-right: none;
-  margin-left: 0.5em;
+  padding-left: 0.25em;
+  padding-right: 0.25em;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-top: 1vh;
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
+  position: relative;
+
+  button {
+    opacity: 0;
+    position: absolute;
+    transition: all 0.5s ease;
+    top: 0;
+
+    &.left-button {
+      left: 0;
+    }
+
+    &.right-button {
+      right: 0;
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
+  }
 `;
 
 const textFlash = keyframes`

--- a/the-toad-tribune/src/layout/Sports.tsx
+++ b/the-toad-tribune/src/layout/Sports.tsx
@@ -9,8 +9,8 @@ import {
   ImageContainer2,
 } from "../commons";
 import { DarkModeProps } from "../api/newsApi";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
 import { dateConverter } from "../utils/dateConverter";
 import { keyframes } from "styled-components";
 
@@ -33,9 +33,10 @@ const Sports: React.FC<INewsProps> = ({
             ? startEnd(articleResponse.articles.length - 1)
             : onPrevButton();
         }}
-        className="add-class"
+        className="left-button"
+        darkMode={darkMode}
       >
-        <img src={PrevIcon} alt="arrow pointing left" />
+        <PreviousButtonIconComponent />
       </Buttons>
 
       <ArticleContentContainer2
@@ -66,8 +67,10 @@ const Sports: React.FC<INewsProps> = ({
             ? startBeginning()
             : onNextButton();
         }}
+        className="right-button"
+        darkMode={darkMode}
       >
-        <img src={NextIcon} alt="arrow pointing right" />
+        <NextButtonIconComponent />
       </Buttons>
     </SportsStyles>
   ) : (
@@ -97,6 +100,28 @@ const SportsStyles = styled.div<DarkModeProps>`
   align-items: center;
   border: none;
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
+  position: relative;
+
+  button {
+    opacity: 0;
+    position: absolute;
+    transition: all 0.5s ease;
+    top: 0;
+
+    &.left-button {
+      left: 0;
+    }
+
+    &.right-button {
+      right: 0;
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
+  }
 `;
 
 const textFlash = keyframes`

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -9,8 +9,8 @@ import {
   ImageContainer2,
 } from "../commons";
 import { DarkModeProps } from "../api/newsApi";
-import PrevIcon from "../commons/prev.png";
-import NextIcon from "../commons/next.png";
+import { ReactComponent as NextButtonIconComponent } from "../assets/next-button.svg";
+import { ReactComponent as PreviousButtonIconComponent } from "../assets/prev-button.svg";
 import { dateConverter } from "../utils/dateConverter";
 import { keyframes } from "styled-components";
 
@@ -33,9 +33,10 @@ const StonksArticle: React.FC<INewsProps> = ({
             ? startEnd(articleResponse.articles.length - 1)
             : onPrevButton();
         }}
-        className="add-class"
+        className="left-button"
+        darkMode={darkMode}
       >
-        <img src={PrevIcon} alt="arrow pointing left" />
+        <PreviousButtonIconComponent />
       </Buttons>
 
       <ArticleContentContainer2
@@ -66,8 +67,10 @@ const StonksArticle: React.FC<INewsProps> = ({
             ? startBeginning()
             : onNextButton();
         }}
+        className="right-button"
+        darkMode={darkMode}
       >
-        <img src={NextIcon} alt="arrow pointing right" />
+        <NextButtonIconComponent />
       </Buttons>
     </StonksStyles>
   ) : (
@@ -101,6 +104,28 @@ const StonksStyles = styled.div<DarkModeProps>`
   cursor: pointer;
   margin-bottom: 0.5em;
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
+  position: relative;
+
+  button {
+    opacity: 0;
+    position: absolute;
+    transition: all 0.5s ease;
+    top: 0;
+
+    &.left-button {
+      left: 0;
+    }
+
+    &.right-button {
+      right: 0;
+    }
+  }
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
+  }
 `;
 
 const textFlash = keyframes`


### PR DESCRIPTION
## Changes
1. Change the `img` tags to use the `svg` tags in order to appear better.
2. Fixed the `button`s to appear as an `absolute` positioning so it would not squeeze the inner articles.
3. Fixed the stylings for the `button`s and `svg`s to appear better on both dark and light modes.

## Purpose
The buttons to paginate through the different articles at the homepage are taking too much space for the inner contents of the articles, and the colors are not dynamically changing for the dark and light modes.

## Approach
The approach is to change the buttons to be in a `absolute` positioning in order to not squeeze the inner contents of the articles and giving them room to breathe. The second approach was to change the tags of the `img` to an `svg` in order to appear better for the user.

Closes #96 