### PR TITLE
Fixed Homepage Responsiveness

### DIFF
--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -8,6 +8,13 @@ export const ArticleContentContainer2 = styled.div`
   flex-direction: column;
   overflow: scroll;
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    max-width: 90%;
+    max-height: 90%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   @media only screen and (max-width: 599px) {
     max-width: 90%;
     max-height: 90%;
@@ -55,6 +62,10 @@ export const HeaderContainer2 = styled.div`
     padding: 5px;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    width: 98%;
+  }
+
   @media only screen and (max-width: 599px) {
     width: 98%;
   }
@@ -68,6 +79,10 @@ export const HeaderContainer2 = styled.div`
     text-align: left;
     line-height: 1.5rem;
     font-family: 'Oswald', sans-serif;
+
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      margin: 0 0 0 2rem;
+    }
 
     @media only screen and (max-width: 599px) {
       margin: 0 0 0 2rem;
@@ -83,6 +98,10 @@ export const HeaderContainer2 = styled.div`
     margin: 0.9rem 0 0 0.4rem;
     font-family: 'Rubik', sans-serif;
 
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      margin: 2rem 0 0 3rem;
+    }
+
     @media only screen and (max-width: 599px) {
       margin: 2rem 0 0 3rem;
     }
@@ -94,6 +113,10 @@ export const HeaderContainer2 = styled.div`
   h5 {
     margin: 0.2rem 0 0 0.4rem;
     font-family: 'Rubik', sans-serif;
+
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      margin: 0 0 0 3rem;
+    }
 
     @media only screen and (max-width: 599px) {
       margin: 0 0 0 3rem;
@@ -108,6 +131,10 @@ export const HeaderContainer2 = styled.div`
 export const DescriptionContainer2 = styled.div`
   font-family: "Times New Roman", Times, serif;
   margin: 1rem;
+
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    margin: 0 0 0 2rem;
+  }
 
   @media only screen and (max-width: 599px) {
     margin: 0 0 0 2rem;

--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -55,6 +55,10 @@ export const HeaderContainer2 = styled.div`
     padding: 5px;
   }
 
+  @media only screen and (max-width: 599px) {
+    width: 98%;
+  }
+
   h3 {
     margin: 0.25rem;
     text-align: left;

--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -59,6 +59,10 @@ export const HeaderContainer2 = styled.div`
     width: 98%;
   }
 
+  @media only screen and (max-width: 479px) {
+    align-items: center;
+  }
+
   h3 {
     margin: 0.25rem;
     text-align: left;
@@ -67,6 +71,11 @@ export const HeaderContainer2 = styled.div`
 
     @media only screen and (max-width: 599px) {
       margin: 0 0 0 2rem;
+    }
+
+    @media only screen and (max-width: 479px) {
+      margin: 0;
+      text-align: center;
     }
   }
 
@@ -77,6 +86,10 @@ export const HeaderContainer2 = styled.div`
     @media only screen and (max-width: 599px) {
       margin: 2rem 0 0 3rem;
     }
+
+    @media only screen and (max-width: 479px) {
+      margin: 2rem 0 0 0;
+    }
   }
   h5 {
     margin: 0.2rem 0 0 0.4rem;
@@ -84,6 +97,10 @@ export const HeaderContainer2 = styled.div`
 
     @media only screen and (max-width: 599px) {
       margin: 0 0 0 3rem;
+    }
+
+    @media only screen and (max-width: 479px) {
+      margin: 0;
     }
   }
 `;
@@ -94,6 +111,11 @@ export const DescriptionContainer2 = styled.div`
 
   @media only screen and (max-width: 599px) {
     margin: 0 0 0 2rem;
+  }
+
+  @media only screen and (max-width: 479px) {
+    margin: 0;
+    text-align: center;
   }
 
   p::first-letter {

--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -25,6 +25,11 @@ export const ImageContainer2 = styled.div`
   justify-content: center;
   align-items: center;
 
+  @media only screen and (max-width: 1199px) {
+    max-width: 65%;
+    height: 100%;
+  }
+
   img {
     width: 100%;
     height: 100%;
@@ -38,6 +43,10 @@ export const HeaderContainer2 = styled.div`
   align-items: flex-start;
   flex-direction: column;
   margin-top: 0.2rem;
+
+  @media only screen and (max-width: 1199px) {
+    padding: 5px;
+  }
 
   h3 {
     margin: 0.25rem;

--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -8,6 +8,13 @@ export const ArticleContentContainer2 = styled.div`
   flex-direction: column;
   overflow: scroll;
 
+  @media only screen and (max-width: 599px) {
+    max-width: 90%;
+    max-height: 90%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   h3 {
     margin: 0 0 1rem 0;
   }
@@ -53,15 +60,27 @@ export const HeaderContainer2 = styled.div`
     text-align: left;
     line-height: 1.5rem;
     font-family: 'Oswald', sans-serif;
+
+    @media only screen and (max-width: 599px) {
+      margin: 0 0 0 2rem;
+    }
   }
 
   h4 {
     margin: 0.9rem 0 0 0.4rem;
     font-family: 'Rubik', sans-serif;
+
+    @media only screen and (max-width: 599px) {
+      margin: 2rem 0 0 3rem;
+    }
   }
   h5 {
     margin: 0.2rem 0 0 0.4rem;
     font-family: 'Rubik', sans-serif;
+
+    @media only screen and (max-width: 599px) {
+      margin: 0 0 0 3rem;
+    }
   }
 `;
 

--- a/the-toad-tribune/src/commons/articleDesign2.ts
+++ b/the-toad-tribune/src/commons/articleDesign2.ts
@@ -88,6 +88,10 @@ export const DescriptionContainer2 = styled.div`
   font-family: "Times New Roman", Times, serif;
   margin: 1rem;
 
+  @media only screen and (max-width: 599px) {
+    margin: 0 0 0 2rem;
+  }
+
   p::first-letter {
     font-size: 30px;
     margin: 0.9rem 0;

--- a/the-toad-tribune/src/layout/Animals.tsx
+++ b/the-toad-tribune/src/layout/Animals.tsx
@@ -103,6 +103,10 @@ const AnimalsStyles = styled.div<DarkModeProps>`
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
   position: relative;
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 7/6/8/9;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Animals.tsx
+++ b/the-toad-tribune/src/layout/Animals.tsx
@@ -110,6 +110,10 @@ const AnimalsStyles = styled.div<DarkModeProps>`
     border-bottom: double;
   }
 
+  @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+    grid-area: 6/6/8/9;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Animals.tsx
+++ b/the-toad-tribune/src/layout/Animals.tsx
@@ -105,6 +105,9 @@ const AnimalsStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 7/6/8/9;
+    margin-bottom: 0;
+    border-top: double;
+    border-bottom: double;
   }
 
   button {

--- a/the-toad-tribune/src/layout/Layout.tsx
+++ b/the-toad-tribune/src/layout/Layout.tsx
@@ -40,13 +40,13 @@ const Layout: React.FC<LayoutProps> = ({
       case "MainLayout":
         return (
           <MainLayoutStyles darkMode={darkMode}>
-            {Animals}
-            {MainArticle}
-            {Movies}
             {Navigation}
+            {MainArticle}
             {Politics}
-            {Sports}
             {Stonks}
+            {Sports}
+            {Animals}
+            {Movies}
             {Weather}
           </MainLayoutStyles>
         );

--- a/the-toad-tribune/src/layout/Layout.tsx
+++ b/the-toad-tribune/src/layout/Layout.tsx
@@ -91,6 +91,10 @@ const MainLayoutStyles = styled.div<DarkModeProps>`
   grid-template-columns: 8% 12% 12% 12% 12% 12% 12% 12% 8%;
   grid-template-rows: repeat(9, 1fr);
   position: fixed;
+
+  @media only screen and (max-width: 1199px) {
+    grid-template-columns: 4.5% 13% 13% 13% 13% 13% 13% 13% 4.5%;
+  }
 `;
 
 

--- a/the-toad-tribune/src/layout/Layout.tsx
+++ b/the-toad-tribune/src/layout/Layout.tsx
@@ -95,6 +95,13 @@ const MainLayoutStyles = styled.div<DarkModeProps>`
   @media only screen and (max-width: 1199px) {
     grid-template-columns: 4.5% 13% 13% 13% 13% 13% 13% 13% 4.5%;
   }
+
+  @media only screen and (max-width: 599px) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+  }
 `;
 
 

--- a/the-toad-tribune/src/layout/Layout.tsx
+++ b/the-toad-tribune/src/layout/Layout.tsx
@@ -96,6 +96,13 @@ const MainLayoutStyles = styled.div<DarkModeProps>`
     grid-template-columns: 4.5% 13% 13% 13% 13% 13% 13% 13% 4.5%;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+  }
+
   @media only screen and (max-width: 599px) {
     display: block;
     width: 100%;

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -177,17 +177,33 @@ const MainArticleHeaderContainer = styled.div`
   flex-direction: column;
 
   .main-content {
+    @media only screen and (max-width: 479px) {
+      text-align: center;
+    }
+
     h3 {
       margin: 0 0 0 2rem;   
       font-family: 'Oswald', sans-serif;
+
+      @media only screen and (max-width: 479px) {
+        margin: 0;
+      }
     }
     h4 {
       margin: 2rem 0 0 3rem;
       font-family: 'Rubik', sans-serif;
+
+      @media only screen and (max-width: 479px) {
+        margin: 2rem 0 0 0;
+      }
     }
     h5 {
       margin: 0 0 0 3rem;
       font-family: 'Rubik', sans-serif;
+
+      @media only screen and (max-width: 479px) {
+        margin: 0;
+      }
     }
   }
 `;
@@ -195,6 +211,11 @@ const MainArticleHeaderContainer = styled.div`
 const MainArticleDescriptionConatiner = styled.div`
   margin: 0 0 0 2rem;
   font-family: 'Times New Roman', Times, serif;
+
+  @media only screen and (max-width: 479px) {
+    margin: 0;
+    text-align: center;
+  }
 
   p::first-letter {
     font-size: 30px;

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -147,6 +147,13 @@ const MainArticleContentContainer = styled.div`
   max-height: 90%;
   max-width: 90%;
   display: flex;
+
+  @media only screen and (max-width: 1199px) {
+    flex-direction: column;
+    align-items: center;
+    margin-left: auto;
+    margin-right: auto;
+  }
 `;
 
 const Image = styled.img`

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -108,6 +108,10 @@ const MainArticleStyles = styled.div<DarkModeProps>`
     overflow: auto;
   }
 
+  @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+    grid-area: 2/2/5/9;
+  }
+
   @media only screen and (max-width: 599px) {
     flex-direction: column;
   }

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -105,6 +105,7 @@ const MainArticleStyles = styled.div<DarkModeProps>`
   @media only screen and (max-width: 1199px) {
     grid-area: 2/2/6/9;
     border-left: none;
+    overflow: auto;
   }
 
   .main-article-title {

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -108,10 +108,18 @@ const MainArticleStyles = styled.div<DarkModeProps>`
     overflow: auto;
   }
 
+  @media only screen and (max-width: 599px) {
+    flex-direction: column;
+  }
+
   .main-article-title {
     position: absolute;
     margin-bottom: 2rem;
     top: 0;
+
+    @media only screen and (max-width: 599px) {
+      position: initial;
+    }
   }
 
   h3 {

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -112,6 +112,10 @@ const MainArticleStyles = styled.div<DarkModeProps>`
     grid-area: 2/2/5/9;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    flex-direction: column;
+  }
+
   @media only screen and (max-width: 599px) {
     flex-direction: column;
   }
@@ -120,6 +124,10 @@ const MainArticleStyles = styled.div<DarkModeProps>`
     position: absolute;
     margin-bottom: 2rem;
     top: 0;
+
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      position: initial;
+    }
 
     @media only screen and (max-width: 599px) {
       position: initial;

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -104,6 +104,7 @@ const MainArticleStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 2/2/6/9;
+    border-left: none;
   }
 
   .main-article-title {

--- a/the-toad-tribune/src/layout/MainArticle.tsx
+++ b/the-toad-tribune/src/layout/MainArticle.tsx
@@ -102,6 +102,10 @@ const MainArticleStyles = styled.div<DarkModeProps>`
   align-items: center;
   position: relative;
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 2/2/6/9;
+  }
+
   .main-article-title {
     position: absolute;
     margin-bottom: 2rem;

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -111,6 +111,7 @@ const MoviesStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 8/5/10/7;
+    border-top: none;
   }
 
   button {

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -119,6 +119,11 @@ const MoviesStyles = styled.div<DarkModeProps>`
     grid-area: 8/7/10/9;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    border-bottom: double;
+    border-left: none;
+  }
+
   @media only screen and (max-width: 599px) {
     border-bottom: double;
     border-left: none;

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -115,6 +115,11 @@ const MoviesStyles = styled.div<DarkModeProps>`
     border-top: none;
   }
 
+  @media only screen and (max-width: 599px) {
+    border-bottom: double;
+    border-left: none;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -109,6 +109,10 @@ const MoviesStyles = styled.div<DarkModeProps>`
   padding-left: 1rem;
   position: relative;
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 8/5/10/7;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -111,6 +111,7 @@ const MoviesStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 8/5/10/7;
+    padding-left: 0;
     border-top: none;
   }
 

--- a/the-toad-tribune/src/layout/Movies.tsx
+++ b/the-toad-tribune/src/layout/Movies.tsx
@@ -115,6 +115,10 @@ const MoviesStyles = styled.div<DarkModeProps>`
     border-top: none;
   }
 
+  @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+    grid-area: 8/7/10/9;
+  }
+
   @media only screen and (max-width: 599px) {
     border-bottom: double;
     border-left: none;

--- a/the-toad-tribune/src/layout/Navgation.tsx
+++ b/the-toad-tribune/src/layout/Navgation.tsx
@@ -116,6 +116,11 @@ const NavigationStyles = styled.div<DarkModeProps>`
       margin: 1vh 0 1vh 1.5vh;
     }
 
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      font-size: 14px;
+      margin: 1vh 0 1vh 0vh;
+    }
+
     @media only screen and (max-width: 599px) {
       font-size: 14px;
       margin: 1vh 0 1vh 0vh;
@@ -149,6 +154,10 @@ const NavLogo = styled.div`
     max-width: 60px;
     max-height: 60px;
     margin: 1rem 1rem 0 2rem;
+  }
+
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    margin: 1rem 1rem 0 1rem;
   }
 
   @media only screen and (max-width: 599px) {
@@ -192,6 +201,10 @@ const NavTitle = styled.h1`
     font-size: 35px;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    font-size: 25px;
+  }
+
   @media only screen and (max-width: 599px) {
     font-size: 25px;
   }
@@ -232,6 +245,10 @@ const NavTitle = styled.h1`
       font-size: 40px;
     }
 
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      font-size: 30px;
+    }
+
     @media only screen and (max-width: 599px) {
       font-size: 30px;
     }
@@ -252,6 +269,10 @@ const NavSearchContainer = styled.div`
 
   @media only screen and (max-width: 899px) {
     margin-left: 20px;
+  }
+
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    margin-left: 10px;
   }
 
   @media only screen and (max-width: 599px) {
@@ -290,6 +311,16 @@ const NavSearch = styled.input<DarkModeProps>`
     font-size: 13px;
     margin-top: 35px;
     margin-right: 30px;
+  }
+
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    width: 100px;
+    height: 20px;
+    font-size: 12px;
+    margin-top: 32px;
+    margin-right: 20px;
+    padding-left: 5px;
+    padding-right: 5px;
   }
 
   @media only screen and (max-width: 599px) {
@@ -340,6 +371,10 @@ const NavSearch = styled.input<DarkModeProps>`
       font-size: 16px;
     }
 
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      font-size: 14px;
+    }
+
     @media only screen and (max-width: 599px) {
       font-size: 14px
     }
@@ -367,6 +402,13 @@ const NavSearchError = styled.span`
   @media only screen and (max-width: 899px) {
     font-size: 10px;
     width: 130px;
+  }
+
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    font-size: 9px;
+    width: 100px;
+    padding-left: 5px;
+    padding-right: 5px;
   }
 
   @media only screen and (max-width: 599px) {

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -114,6 +114,7 @@ const PoliticsStyles = styled.div<DarkModeProps>`
   @media only screen and (max-width: 599px) {
     margin-top: 1vh;
     padding: 1rem;
+    border-right: none;
   }
 
   button {

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -107,6 +107,8 @@ const PoliticsStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 6/2/8/6;
+    margin-top: 0;
+    border-right: double;
   }
 
   button {

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -115,6 +115,12 @@ const PoliticsStyles = styled.div<DarkModeProps>`
     grid-area: 5/2/8/6;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    margin-top: 1vh;
+    padding: 1rem;
+    border-right: none;
+  }
+
   @media only screen and (max-width: 599px) {
     margin-top: 1vh;
     padding: 1rem;

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -105,6 +105,10 @@ const PoliticsStyles = styled.div<DarkModeProps>`
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
   position: relative;
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 6/2/8/6;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -111,6 +111,10 @@ const PoliticsStyles = styled.div<DarkModeProps>`
     border-right: double;
   }
 
+  @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+    grid-area: 5/2/8/6;
+  }
+
   @media only screen and (max-width: 599px) {
     margin-top: 1vh;
     padding: 1rem;

--- a/the-toad-tribune/src/layout/Politics.tsx
+++ b/the-toad-tribune/src/layout/Politics.tsx
@@ -111,6 +111,11 @@ const PoliticsStyles = styled.div<DarkModeProps>`
     border-right: double;
   }
 
+  @media only screen and (max-width: 599px) {
+    margin-top: 1vh;
+    padding: 1rem;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Sports.tsx
+++ b/the-toad-tribune/src/layout/Sports.tsx
@@ -102,6 +102,10 @@ const SportsStyles = styled.div<DarkModeProps>`
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
   position: relative;
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 8/2/10/5;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -108,6 +108,8 @@ const StonksStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 6/6/7/9;
+    border-right: none;
+    border-left: none;
   }
 
   button {

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -113,8 +113,8 @@ const StonksStyles = styled.div<DarkModeProps>`
   }
 
   @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
-    /* grid-area: 5/6/6/9; */
     grid-area: 8/5/10/7;
+    border-left: double;
   }
 
   @media only screen and (max-width: 599px) {

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -112,6 +112,11 @@ const StonksStyles = styled.div<DarkModeProps>`
     border-left: none;
   }
 
+  @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+    /* grid-area: 5/6/6/9; */
+    grid-area: 8/5/10/7;
+  }
+
   @media only screen and (max-width: 599px) {
     border-bottom: double;
   }

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -106,6 +106,10 @@ const StonksStyles = styled.div<DarkModeProps>`
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
   position: relative;
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 6/6/7/9;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -117,6 +117,10 @@ const StonksStyles = styled.div<DarkModeProps>`
     border-left: double;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    border-bottom: double;
+  }
+
   @media only screen and (max-width: 599px) {
     border-bottom: double;
   }

--- a/the-toad-tribune/src/layout/Stonks.tsx
+++ b/the-toad-tribune/src/layout/Stonks.tsx
@@ -112,6 +112,10 @@ const StonksStyles = styled.div<DarkModeProps>`
     border-left: none;
   }
 
+  @media only screen and (max-width: 599px) {
+    border-bottom: double;
+  }
+
   button {
     opacity: 0;
     position: absolute;

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -57,6 +57,7 @@ const WeatherStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 8/7/10/9;
+    margin-top: 0;
   }
 
   & .temp-location {

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -82,6 +82,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
       margin-top: 25px;
     }
 
+    @media only screen and (max-width: 599px) {
+      width: 15%;
+    }
+
     div {
       margin-top: 5%;
     }

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -62,6 +62,9 @@ const WeatherStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
     grid-area: 5/6/6/9;
+    flex-direction: row;
+    justify-content: space-around;
+    border-left: none;
   }
 
   @media only screen and (max-width: 599px) {
@@ -84,6 +87,11 @@ const WeatherStyles = styled.div<DarkModeProps>`
     @media only screen and (max-width: 1199px) {
       width: 35%;
       margin-top: 25px;
+    }
+
+    @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+      width: 9%;
+      margin-top: 0;
     }
 
     @media only screen and (max-width: 599px) {
@@ -109,6 +117,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
   & .weather-localtime {
     @media only screen and (max-width: 1199px) {
       margin-top: 25px;
+    }
+
+    @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+      margin-top: 0;
     }
   }
 

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -60,6 +60,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
     justify-content: start;
   }
 
+  @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
+    grid-area: 5/6/6/9;
+  }
+
   @media only screen and (max-width: 599px) {
     border: none;
   }

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -67,6 +67,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
     border-left: none;
   }
 
+  @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+    border: none;
+  }
+
   @media only screen and (max-width: 599px) {
     border: none;
   }
@@ -92,6 +96,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
     @media only screen and (max-width: 1199px) and (min-width: 992px) and (orientation: landscape) {
       width: 9%;
       margin-top: 0;
+    }
+
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      width: 15%;
     }
 
     @media only screen and (max-width: 599px) {
@@ -131,6 +139,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
     justify-content: center;
     overflow: hidden;
     position: relative;
+
+    @media only screen and (max-width: 991px) and (min-width: 600px) and (orientation: landscape) {
+      height: 330px;
+    }
 
     @media only screen and (max-width: 599px) {
       height: 330px;

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -60,6 +60,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
     justify-content: start;
   }
 
+  @media only screen and (max-width: 599px) {
+    border: none;
+  }
+
   & .temp-location {
     font-weight: 700;
 

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -116,6 +116,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
     overflow: hidden;
     position: relative;
 
+    @media only screen and (max-width: 599px) {
+      height: 330px;
+    }
+
     img {
       position: absolute;
       height: 150px;

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -55,6 +55,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
   margin-top: 1vh;
   color: ${(props) => (props.darkMode ? "#e3dac9" : "#1a1a1a")};
 
+  @media only screen and (max-width: 1199px) {
+    grid-area: 8/7/10/9;
+  }
+
   & .temp-location {
     font-weight: 700;
   }

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -62,6 +62,10 @@ const WeatherStyles = styled.div<DarkModeProps>`
 
   & .temp-location {
     font-weight: 700;
+
+    @media only screen and (max-width: 899px) {
+      text-align: center;
+    }
   }
 
   .icon-temp-container {

--- a/the-toad-tribune/src/layout/Weather.tsx
+++ b/the-toad-tribune/src/layout/Weather.tsx
@@ -15,7 +15,7 @@ const Weather: React.FC<IWeatherProp> = ({ darkMode, weatherResponse }) => {
             <img src={weatherResponse.current.weather_icons[0]} />
             <div>{weatherResponse.current.temperature}°F</div>
           </div>
-          <div>{weatherResponse.location.localtime.split(" ")[0]}</div>
+          <div className="weather-localtime">{weatherResponse.location.localtime.split(" ")[0]}</div>
         </>
       ) : (
         <div className="baby-sun-container">
@@ -57,7 +57,7 @@ const WeatherStyles = styled.div<DarkModeProps>`
 
   @media only screen and (max-width: 1199px) {
     grid-area: 8/7/10/9;
-    margin-top: 0;
+    justify-content: start;
   }
 
   & .temp-location {
@@ -69,6 +69,11 @@ const WeatherStyles = styled.div<DarkModeProps>`
     align-items: center;
     flex-direction: column;
 
+    @media only screen and (max-width: 1199px) {
+      width: 35%;
+      margin-top: 25px;
+    }
+
     div {
       margin-top: 5%;
     }
@@ -78,8 +83,18 @@ const WeatherStyles = styled.div<DarkModeProps>`
     height: 60px;
     width: 60px;
     border-radius: 50%;
+
+    @media only screen and (max-width: 1199px) {
+      width: 100%;
+      height: 100%;
+    }
   }
   
+  & .weather-localtime {
+    @media only screen and (max-width: 1199px) {
+      margin-top: 25px;
+    }
+  }
 
   .baby-sun-container {
     height: 100%;


### PR DESCRIPTION
## Changes
1. Fixed the responsiveness on all max-width viewports of `1199px`, `899px`, `599px`, `479px`, and `379px`.
2. Also fixed the responsiveness on landscape viewports between `max-width: 991px` and `min-width: 600px`, and between `max-width: 1199px` and `min-width: 992px`.

## Purpose
The Homepage is not responsive anywhere below `1199px`.

## Approach
The approach was to carefully target and style all max-width viewports of `1199px`, `899px`, `599px`, `479px`, and `379px`. Also, on landscape mode, the viewports between `max-width: 991px` and `min-width: 600px`, and between `max-width: 1199px` and `min-width: 992px` were also carefully targeted and styled.

Multiple things were changed and readjusted, but it was necessary to make a beautiful UI for the user.

Closes #105 