### PR TITLE
Fixed NewsAPI Handler

### DIFF
--- a/the-toad-tribune/src/SubApp.tsx
+++ b/the-toad-tribune/src/SubApp.tsx
@@ -68,7 +68,6 @@ const SubApp = () => {
   
   const [serverErrorMessage, setServerErrorMessage] = useState<string>("");
 
-
   const [pageNumber, setPageNumber] = useState<number>(1);
 
   const [darkMode, setdarkMode] = useState<Boolean>(true);
@@ -80,7 +79,7 @@ const SubApp = () => {
         setMainArticle(res)
       }
 
-      if (res.status === 'error') {
+      if (res.status === 'error' || res.status === "fail") {
         setServerErrorMessage(res.message);
       }
     });
@@ -91,7 +90,7 @@ const SubApp = () => {
         setAnimalArticle(res)
       }
 
-      if (res.status === 'error') {
+      if (res.status === 'error' || res.status === "fail") {
         setServerErrorMessage(res.message);
       }
     });
@@ -102,7 +101,7 @@ const SubApp = () => {
         setSportsArticle(res)
       }
 
-      if (res.status === 'error') {
+      if (res.status === 'error' || res.status === "fail") {
         setServerErrorMessage(res.message);
       }
     });
@@ -112,7 +111,7 @@ const SubApp = () => {
         setPoliticsArticle(res)
       }
 
-      if (res.status === 'error') {
+      if (res.status === 'error' || res.status === "fail") {
         setServerErrorMessage(res.message);
       }
   });
@@ -123,7 +122,7 @@ const SubApp = () => {
         setMoviesArticle(res)
       }
 
-      if (res.status === 'error') {
+      if (res.status === 'error' || res.status === "fail") {
         setServerErrorMessage(res.message);
       }
     });
@@ -134,7 +133,7 @@ const SubApp = () => {
         setStonksArticle(res)
       }
 
-      if (res.status === 'error') {
+      if (res.status === 'error' || res.status === "fail") {
         setServerErrorMessage(res.message);
       }
     });

--- a/the-toad-tribune/src/api/newsApi.ts
+++ b/the-toad-tribune/src/api/newsApi.ts
@@ -106,7 +106,7 @@ export class NewsEverythingRequest implements INewsEverythingRequest {
 export const getNewsEverything = async (
   request: INewsEverythingRequest
 ): Promise<NewsResponse> => {
-  const endpoint = `${process.env.REACT_APP_NEWS_API}/everything`;
+  const endpoint = `${process.env.REACT_APP_NODE_NEWS_API}/everything`;
 
   let queryString = `${endpoint}/?apiKey=${request.apiKey}&q=${request.q}&qInTitle=${request.qInTitle}`;
 
@@ -188,7 +188,7 @@ export class NewsTopHeadlinesRequest implements INewsTopHeadlinesRequest {
 export const getNewsTopHeadlines = async (
   request: INewsTopHeadlinesRequest
 ): Promise<NewsResponse> => {
-  const endpoint = `${process.env.REACT_APP_NEWS_API}/top-headlines`;
+  const endpoint = `${process.env.REACT_APP_NODE_NEWS_API}/top-headlines`;
 
   let queryString = `${endpoint}/?apiKey=${request.apiKey}&q=${request.q}`;
 

--- a/the-toad-tribune/src/layout/SearchResults.tsx
+++ b/the-toad-tribune/src/layout/SearchResults.tsx
@@ -68,7 +68,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         setSearchResults(results);
       }
 
-      if (results.status === "error") {
+      if (results.status === "error" || results.status === "fail") {
         setSnackbarMessage(results.message);
       }
     });
@@ -89,7 +89,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         setSearchResults(results);
       }
 
-      if (results.status === "error") {
+      if (results.status === "error" || results.status === "fail") {
         setSnackbarMessage(results.message);
       }
     });


### PR DESCRIPTION
## Changes
1. Changed the endpoint for the NewsAPI to the Node-NewsAPI.
2. Accounted the server errors for anything with "fail".

## Purpose
The structure of the code needs to be changed to account for the new BackEnd.

## Approach
By restructuring the code for the Node-NewsAPI, we no longer need to be reliant on the NewsAPI on the FrontEnd. This helps us to host our website with a domain.

Closes #109 